### PR TITLE
SUIK-100: Destroy the toast if Navigate is missing a navigationContro…

### DIFF
--- a/Sources/SwiftUIKit/Navigation/Navigate.swift
+++ b/Sources/SwiftUIKit/Navigation/Navigate.swift
@@ -296,6 +296,7 @@ public class Navigate {
         guard let controller = navigationController,
             let containerView = controller.visibleViewController?.view,
             let toast = toast else {
+                destroyToast()
                 print("Navigate \(#function) Error!")
                 print("Issue trying to dismiss presentingViewController")
                 print("Error: Could not unwrap navigationController")


### PR DESCRIPTION
Closes: #100 

Example of Issue Fixed:
```
Navigate.shared.toast {
    View(backgroundColor: .blue).frame(height: 100)
} // Won't show because the navigationController hasn't been passed to Navigate
        
Navigate.shared.configure(controller: navigationController)
               
Navigate.shared.toast {
    View(backgroundColor: .red).frame(height: 100)
} // Won't show since toast is not nil
```